### PR TITLE
Eg/add requestor

### DIFF
--- a/lib/api/common.ex
+++ b/lib/api/common.ex
@@ -43,7 +43,7 @@ defmodule Zendesk.CommonApi do
     |> parse_response(parse_method, full_endpoint)
   end
 
-  def parse_response(%HTTPotion.Response{status_code: status_code, body: body}, parse_method, endpoint)
+  def parse_response(%HTTPotion.Response{status_code: status_code, body: body}, _parse_method, endpoint)
   when status_code == 401 or status_code == 404 do
     IO.inspect endpoint
 
@@ -59,7 +59,7 @@ defmodule Zendesk.CommonApi do
     parse_response(body: response.body, parse_method: parse_method)
   end
 
-  def parse_response(body: body, parse_method: parse_method)
+  def parse_response(body: body, parse_method: _)
   when body == " " or body == "" or is_nil(body) do
     :ok
   end

--- a/lib/api/ticket_api.ex
+++ b/lib/api/ticket_api.ex
@@ -80,18 +80,6 @@ defmodule Zendesk.TicketApi do
   end
 
   @doc """
-  Fetch a ticket with ID
-
-  `account`: The Zendesk.Account to use
-
-  `ticket_id`: Thec ticket ID to fetch
-  """
-  def show_ticket(account, ticket_id: ticket_id) do
-    perform_request(&parse_single_ticket/1, account: account, verb: :get,
-    endpoint: ticket_url(ticket_id))
-  end
-
-  @doc """
   Fetch a group of tickets
 
   `account`: The Zendesk.Account to use
@@ -116,6 +104,18 @@ defmodule Zendesk.TicketApi do
   def show_ticket(account, requester_id: requeser_id) do
     perform_request(&parse_multiple_tickets/1, account: account, verb: :get,
     endpoint: ExPrintf.sprintf(@by_requester, [requeser_id]))
+  end
+
+  @doc """
+  Fetch a ticket with ID
+
+  `account`: The Zendesk.Account to use
+
+  `ticket_id`: Thec ticket ID to fetch
+  """
+  def show_ticket(account, ticket_id: ticket_id) do
+    perform_request(&parse_single_ticket/1, account: account, verb: :get,
+    endpoint: ticket_url(ticket_id))
   end
 
   @doc """

--- a/lib/main.ex
+++ b/lib/main.ex
@@ -1,1 +1,0 @@
-# NewTest.doit

--- a/lib/models/common_utils.ex
+++ b/lib/models/common_utils.ex
@@ -50,7 +50,7 @@ defmodule Zendesk.CommonUtils do
     raise error_msg
   end
 
-  def set_map_item(map, key, value, contains, error_msg) do
+  def set_map_item(map, key, value, _contains, _error_msg) do
     Map.put(map, key, value)
   end
 

--- a/lib/models/field.ex
+++ b/lib/models/field.ex
@@ -1,5 +1,0 @@
-# defmodule Zendesk.Field do
-#
-#   defstruct [:id, :value]
-#
-# end

--- a/lib/models/requester.ex
+++ b/lib/models/requester.ex
@@ -1,9 +1,0 @@
-# defmodule Zendesk.Requester do
-#
-#   defstruct [:name, :email]
-#
-#   def create(name, email) do
-#     %Zendesk.Requester{name: name, email: email}
-#   end
-#
-# end

--- a/lib/models/ticket.ex
+++ b/lib/models/ticket.ex
@@ -25,6 +25,22 @@ defmodule Zendesk.Ticket do
   end
 
   @doc """
+  Add a requester with name and email to the ticket
+
+  `name`: requester name
+
+  `email`: requester email
+  """
+  def add_requester(ticket, name: name, email: email) do
+    Map.put(ticket, :requester, %{name: name, email: email})
+  end
+
+  def add_requester(ticket, email: email) do
+    Map.put(ticket, :requester, %{name: email, email: email})
+  end
+
+
+  @doc """
   Add a custom field in the ticket
 
   `id`: the custom field id
@@ -49,7 +65,6 @@ defmodule Zendesk.Ticket do
   def add_collaborator(ticket, email: email) do
     add_list_item(ticket, :collaborators, email)
   end
-
 
   @doc """
   Add a collaborator with an id to the ticket

--- a/lib/models/view.ex
+++ b/lib/models/view.ex
@@ -41,7 +41,7 @@ defmodule Zendesk.View do
     add_list_item(view, type, %{field: title, operator: operator, value: value})
   end
 
-  def add_condition(view, map), do: raise "Wrong condition type passed \"#{to_char_list(map[:type])}\""
+  def add_condition(_view, map), do: raise "Wrong condition type passed \"#{to_char_list(map[:type])}\""
 
   # @condition_types [:all, :any]
   # def add_condition(view, type: type, field: title, operator: operator, value: value) do

--- a/mix.exs
+++ b/mix.exs
@@ -40,6 +40,6 @@ defmodule NewTest.Mixfile do
       {:exprintf, github: "parroty/exprintf"},
       {:exvcr, "~> 0.7", only: :test},
       {:coverex, "~> 1.4.7", only: :test},
-      {:inch_ex, only: :docs}]
+      {:inch_ex, ">= 0.0.0", only: :docs}]
   end
 end

--- a/test/ticket_test.exs
+++ b/test/ticket_test.exs
@@ -17,6 +17,13 @@ defmodule TicketTest do
     assert ticket.subject == "The subject"
   end
 
+  test "it can create a ticket and set the requestor" do
+    ticket = Ticket.new("Hello") |> Ticket.add_requester(email: "test@test.net")
+
+    assert ticket.comment.body == "Hello"
+    assert ticket.requester == %{email: "test@test.net", name: "test@test.net"}
+  end
+
   test "it can create a ticket with requeser_id" do
     ticket = Ticket.new("Hello") |> Ticket.set_requester_id("123")
 


### PR DESCRIPTION
Adding ability to set the requestor for a ticket.  Giving both the option to set requester name and email or just the email which would then be used for the name
