### PR TITLE
Add deps badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Zenixir
 [![Build Status](https://travis-ci.org/oarrabi/zenixir.svg)](https://travis-ci.org/oarrabi/zenixir)
 [![Coverage Status](https://coveralls.io/repos/oarrabi/zenixir/badge.svg?branch=master&service=github)](https://coveralls.io/github/oarrabi/zenixir?branch=master)
+[![Deps Status](https://beta.hexfaktor.org/badge/all/github/oarrabi/zenixir.svg)](https://beta.hexfaktor.org/github/oarrabi/zenixir)
 [![Inline docs](http://inch-ci.org/github/oarrabi/zenixir.svg)](http://inch-ci.org/github/oarrabi/zenixir)
 [![Issue Count](https://codeclimate.com/github/oarrabi/zenixir/badges/issue_count.svg)](https://codeclimate.com/github/oarrabi/zenixir)
 


### PR DESCRIPTION
Hi there,

I'm the maintainer of [Inch CI](https://inch-ci.org/) and this PR pitches my latest project for the Elixir community.

Here comes the pitch:

[![Deps Status](https://beta.hexfaktor.org/badge/all/github/oarrabi/zenixir.svg)](https://beta.hexfaktor.org/github/oarrabi/zenixir) [![Inline docs](http://inch-ci.org/github/oarrabi/zenixir.svg?branch=master)](http://inch-ci.org/github/oarrabi/zenixir)

You already know the Inch badge on the right: It shows you an analysis for your Elixir project's docs. The new badge does the same thing for your dependencies.

Behind the badge works a CI service written in Elixir which can notify you whenever important updates for your Hex packages are released.

This is still in its infancy, and I want to basically invite you to join the beta to test-drive this. I really believe that we can create a great service for the community with this. That said, don't feel any obligation to accept the PR. You can't hurt my feelings by voicing your honest opinion about this idea!
