### PR TITLE
Use hackney keyword list for token auth.

### DIFF
--- a/lib/models/account.ex
+++ b/lib/models/account.ex
@@ -57,7 +57,7 @@ defmodule Zendesk.Account do
   """
   def auth(%Zendesk.Account{email: email, token: token})
   when not is_nil token != nil do
-     [basic_auth: {email <> "/token", token}]
+     [hackney: [basic_auth: {email <> "/token", token}]]
   end
 
 end


### PR DESCRIPTION
For Poison, basicauth params need to be nested under the `hackney` keyword. #6 made this change for email/password auth but not for email/token auth.
