### PR TITLE
Fix elixir 1.4 warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Elixir Zendesk API Client
 Add zenixir to your `mix.exs` deps
 
 	def deps do
-	  [{:zenixir, github: "oarrabi/zenixir"}]
+	  [{:zenixir, github: "nsomar/zenixir"}]
 	end
 
 ## Documentation

--- a/lib/api/account_settings_api.ex
+++ b/lib/api/account_settings_api.ex
@@ -18,7 +18,7 @@ defmodule Zendesk.AccountSettingsApi do
   # Private
 
   defp parse_account_settings(response) do
-    Poison.Parser.parse(response, keys: :atoms) |> elem(1) |> Dict.get(:settings)
+    Poison.Parser.parse(response, keys: :atoms) |> elem(1) |> Map.get(:settings)
   end
 
 end

--- a/lib/api/attachments_api.ex
+++ b/lib/api/attachments_api.ex
@@ -62,11 +62,11 @@ defmodule Zendesk.AttachmentApi do
   end
 
   defp parse_upload(response) do
-    Poison.Parser.parse(response, keys: :atoms) |> elem(1) |> Dict.get(:upload)
+    Poison.Parser.parse(response, keys: :atoms) |> elem(1) |> Map.get(:upload)
   end
 
   defp parse_attachment(response) do
-    Poison.Parser.parse(response, keys: :atoms) |> elem(1) |> Dict.get(:attachment)
+    Poison.Parser.parse(response, keys: :atoms) |> elem(1) |> Map.get(:attachment)
   end
 
 end

--- a/lib/api/automations_api.ex
+++ b/lib/api/automations_api.ex
@@ -3,6 +3,8 @@ defmodule Zendesk.AutomationsApi do
   @moduledoc """
   Module that contains fucntions to deal with Zendesk searches
   """
+  
+  use Zendesk.CommonApi
 
   @list_automations "/automations.json"
   @get_automations "/automations/%s.json"
@@ -10,7 +12,8 @@ defmodule Zendesk.AutomationsApi do
   @create_automation "/automations.json"
   @update_automation "/automations/%s.json"
   @delete_automation "/automations/%s.json"
-  use Zendesk.CommonApi
+
+  @headers ["Content-Type": "application/json"]
 
 
   @doc """
@@ -20,9 +23,9 @@ defmodule Zendesk.AutomationsApi do
 
   """
   def list_automations(account) do
-    perform_request(&Zendesk.Ticket.incremental_from_json_array/1, 
-                    account: account, 
-                    verb: :get, 
+    perform_request(&Zendesk.Ticket.incremental_from_json_array/1,
+                    account: account,
+                    verb: :get,
                     endpoint: @list_automations)
   end
 
@@ -35,9 +38,9 @@ defmodule Zendesk.AutomationsApi do
 
   """
   def get_automations(account, automation_id) do
-    perform_request(&Zendesk.Ticket.incremental_from_json_array/1, 
-                    account: account, 
-                    verb: :get, 
+    perform_request(&Zendesk.Ticket.incremental_from_json_array/1,
+                    account: account,
+                    verb: :get,
                     endpoint: ExPrintf.sprintf(@get_automations, [automation_id]))
   end
 
@@ -48,9 +51,9 @@ defmodule Zendesk.AutomationsApi do
 
   """
   def list_active_automations(account) do
-    perform_request(&Zendesk.Ticket.incremental_from_json_array/1, 
-                    account: account, 
-                    verb: :get, 
+    perform_request(&Zendesk.Ticket.incremental_from_json_array/1,
+                    account: account,
+                    verb: :get,
                     endpoint: @list_active_automations)
   end
 
@@ -64,12 +67,12 @@ defmodule Zendesk.AutomationsApi do
   """
   def create_automation(account, automation) do
     json = Zendesk.Ticket.to_json(%{automation: automation})
-    perform_request(&Zendesk.Ticket.incremental_from_json_array/1, 
-                    account: account, 
-                    verb: :post, 
-                    endpoint: @create_automation, 
-                    body: json, 
-                    headers: headers)
+    perform_request(&Zendesk.Ticket.incremental_from_json_array/1,
+                    account: account,
+                    verb: :post,
+                    endpoint: @create_automation,
+                    body: json,
+                    headers: @headers)
   end
 
   @doc """
@@ -86,12 +89,12 @@ defmodule Zendesk.AutomationsApi do
   def update_automation(account, automation, automation_id) do
     json = Zendesk.Ticket.to_json(%{automation: automation})
     IO.inspect json
-    perform_request(&Zendesk.Ticket.incremental_from_json_array/1, 
-                    account: account, 
-                    verb: :put, 
-                    endpoint: ExPrintf.sprintf(@update_automation, [automation_id]), 
-                    body: json, 
-                    headers: headers)
+    perform_request(&Zendesk.Ticket.incremental_from_json_array/1,
+                    account: account,
+                    verb: :put,
+                    endpoint: ExPrintf.sprintf(@update_automation, [automation_id]),
+                    body: json,
+                    headers: @headers)
   end
 
   @doc """
@@ -104,15 +107,11 @@ defmodule Zendesk.AutomationsApi do
   """
 
   def delete_automation(account, automation_id) do
-    perform_request(&parse_delete/1, 
-                    account: account, 
-                    verb: :delete, 
-                    endpoint: ExPrintf.sprintf(@delete_automation, [automation_id]), 
-                    headers: headers)
-  end
-
-  defp headers do
-    ["Content-Type": "application/json"]
+    perform_request(&parse_delete/1,
+                    account: account,
+                    verb: :delete,
+                    endpoint: ExPrintf.sprintf(@delete_automation, [automation_id]),
+                    headers: @headers)
   end
 
   defp parse_delete(response) do

--- a/lib/api/brand_api.ex
+++ b/lib/api/brand_api.ex
@@ -30,11 +30,11 @@ defmodule Zendesk.BrandApi do
   # Private
 
   defp prase_brands(response) do
-    Poison.Parser.parse(response, keys: :atoms) |> elem(1) |> Dict.get(:brands)
+    Poison.Parser.parse(response, keys: :atoms) |> elem(1) |> Map.get(:brands)
   end
 
   defp prase_brand(response) do
-    Poison.Parser.parse(response, keys: :atoms) |> elem(1) |> Dict.get(:brand)
+    Poison.Parser.parse(response, keys: :atoms) |> elem(1) |> Map.get(:brand)
   end
 
 end

--- a/lib/api/comment_api.ex
+++ b/lib/api/comment_api.ex
@@ -3,6 +3,7 @@ defmodule Zendesk.CommentApi do
   @moduledoc """
   Module that contains fucntions to deal with Zendesk comments
   """
+  use Zendesk.CommonApi
 
   @all_comments_for_ticket "/tickets/%s/comments.json"
   @redact_comment "/tickets/%s/comments/%s/redact.json"
@@ -10,7 +11,8 @@ defmodule Zendesk.CommentApi do
 
   @all_comments_for_request "/requests/%s/comments.json"
   @comment_for_request "/requests/%s/comments/%s.json"
-  use Zendesk.CommonApi
+
+  @headers ["Content-Type": "application/json"]
 
 
   @doc """
@@ -55,7 +57,7 @@ defmodule Zendesk.CommentApi do
     verb: :put,
     endpoint: ExPrintf.sprintf(@redact_comment, [ticket_id, comment_id]),
     body: redact_json(text),
-    headers: headers)
+    headers: @headers)
   end
 
   @doc """
@@ -75,13 +77,8 @@ defmodule Zendesk.CommentApi do
     %{text: text} |> Poison.encode |> elem(1)
   end
 
-  defp headers do
-    ["Content-Type": "application/json"]
-  end
-
   defp parse_get_comment(response) do
     Zendesk.Comment.from_json(response)
-
   end
 
   defp parse_get_comments(response) do

--- a/lib/api/common.ex
+++ b/lib/api/common.ex
@@ -6,11 +6,11 @@ defmodule Zendesk.CommonApi do
       defp perform_request(parse_method, args) do
         import Zendesk.CommonApi
         internal_perform_request(parse_method,
-        account: Dict.get(args, :account),
-        verb:  Dict.get(args, :verb),
-        endpoint: Dict.get(args, :endpoint),
-        body: Dict.get(args, :body),
-        headers: Dict.get(args, :headers))
+        account: Keyword.get(args, :account),
+        verb:  Keyword.get(args, :verb),
+        endpoint: Keyword.get(args, :endpoint),
+        body: Keyword.get(args, :body),
+        headers: Keyword.get(args, :headers))
       end
 
       defp perform_upload_file(parse_method, account: account, endpoint: endpoint, file: file) do
@@ -42,7 +42,7 @@ defmodule Zendesk.CommonApi do
     |> parse_response(parse_method, full_endpoint)
   end
 
-  def parse_response(%HTTPoison.Response{status_code: status_code, body: body}, _parse_method, endpoint)
+  def parse_response(%HTTPoison.Response{status_code: status_code, body: body}, _parse_method, _endpoint)
   when status_code == 401 or status_code == 404 do
     Zendesk.Error.from_json(body)
   end
@@ -62,7 +62,7 @@ defmodule Zendesk.CommonApi do
   end
 
   def prepare_params(account, body, headers) do
-    empty_params
+    empty_params()
     |> add_auth(account)
     |> add_body(body)
     |> add_headers(headers)

--- a/lib/api/group_membership_api.ex
+++ b/lib/api/group_membership_api.ex
@@ -65,11 +65,11 @@ defmodule Zendesk.GroupMembershipApi do
   # Private
 
   defp parse_all_membership(response) do
-    Poison.Parser.parse(response, keys: :atoms) |> elem(1) |> Dict.get(:group_memberships)
+    Poison.Parser.parse(response, keys: :atoms) |> elem(1) |> Map.get(:group_memberships)
   end
 
   defp parse_single_membership(response) do
-    Poison.Parser.parse(response, keys: :atoms) |> elem(1) |> Dict.get(:group_membership)
+    Poison.Parser.parse(response, keys: :atoms) |> elem(1) |> Map.get(:group_membership)
   end
 
 end

--- a/lib/api/organization_api.ex
+++ b/lib/api/organization_api.ex
@@ -52,7 +52,7 @@ defmodule Zendesk.OrganizationApi do
   # Private
 
   defp parse_organization(response) do
-    Poison.Parser.parse(response, keys: :atoms) |> elem(1) |> Dict.get(:organization)
+    Poison.Parser.parse(response, keys: :atoms) |> elem(1) |> Map.get(:organization)
   end
 
   defp parse_get_organizations(response) do

--- a/lib/api/request_api.ex
+++ b/lib/api/request_api.ex
@@ -4,14 +4,16 @@ defmodule Zendesk.RequestApi do
   Module that contains fucntions to deal with Zendesk requests
   """
 
+  use Zendesk.CommonApi
+
   @endpoint "/requests.json"
   @request_status "/requests.json?%s"
   @request_for_user "/users/%s/requests.json"
   @request_for_organization "/organizations/%s/requests.json"
   @search_requests "/requests/search.json?query=\"%s\""
   @single_request "/requests/%s.json"
-  use Zendesk.CommonApi
 
+  @headers ["Content-Type": "application/json"]
 
   @doc """
   Get all the requests
@@ -79,7 +81,7 @@ defmodule Zendesk.RequestApi do
   def create_request(account, request: request) do
     json = Zendesk.Request.to_json(%{request: request})
     perform_request(&parse_request/1, account: account, verb: :post, endpoint: @endpoint,
-    body: json, headers: headers)
+    body: json, headers: @headers)
   end
 
   @doc """
@@ -93,14 +95,10 @@ defmodule Zendesk.RequestApi do
     json = Zendesk.Request.to_json(%{request: request})
     perform_request(&parse_request/1, account: account, verb: :put,
     endpoint: ExPrintf.sprintf(@single_request, [request_id]),
-    body: json, headers: headers)
+    body: json, headers: @headers)
   end
 
   # Private
-
-  defp headers do
-    ["Content-Type": "application/json"]
-  end
 
   defp parse_request(response) do
     Zendesk.Request.from_json(response)

--- a/lib/api/tags_api.ex
+++ b/lib/api/tags_api.ex
@@ -4,12 +4,13 @@ defmodule Zendesk.TagsApi do
   Module that contains fucntions to deal with Zendesk tags
   """
 
+  use Zendesk.CommonApi
+
   @endpoint "/tags.json"
   @tags_for_ticket "/tickets/%s/tags.json"
   @tags_for_user "/users/%s/tags.json"
 
-  use Zendesk.CommonApi
-
+  @headers ["Content-Type": "application/json"]
 
   @doc """
   Get a list of all tags
@@ -97,7 +98,7 @@ defmodule Zendesk.TagsApi do
     perform_tag_request(account, verb: :delete,
     endpoint: @tags_for_ticket, id: ticket_id, tags: tags)
   end
-  
+
   @doc """
   Delete user tags
 
@@ -116,21 +117,19 @@ defmodule Zendesk.TagsApi do
     account: account,
     verb: verb,
     endpoint: ExPrintf.sprintf(endpoint, [id]),
-    headers: headers,
+    headers: @headers,
     body: tags |> list_to_json(:tags))
   end
 
 
   # Private
 
-  defp headers, do: ["Content-Type": "application/json"]
-
   defp list_to_json(list, key) do
     Poison.encode!(Map.put(%{}, key, list))
   end
 
   defp parse_tags(response) do
-    Poison.Parser.parse(response, keys: :atoms) |> elem(1) |> Dict.get(:tags)
+    Poison.Parser.parse(response, keys: :atoms) |> elem(1) |> Map.get(:tags)
   end
 
 end

--- a/lib/api/targets_api.ex
+++ b/lib/api/targets_api.ex
@@ -4,13 +4,15 @@ defmodule Zendesk.TargetsApi do
   Module that contains fucntions to deal with Zendesk searches
   """
 
+  use Zendesk.CommonApi
+
   @list_targets "/targets.json"
   @show_targets "/targets/%s.json"
   @create_target "/targets.json"
   @update_target "/targets/%s.json"
-  @reorder_targets "/targets/reorder.json"
-  use Zendesk.CommonApi
+  @delete_target "/targets/%s.json"
 
+  @headers ["Content-Type": "application/json"]
 
   @doc """
   List targets
@@ -19,9 +21,9 @@ defmodule Zendesk.TargetsApi do
 
   """
   def list_targets(account) do
-    perform_request(&Zendesk.Ticket.incremental_from_json_array/1, 
-                    account: account, 
-                    verb: :get, 
+    perform_request(&Zendesk.Ticket.incremental_from_json_array/1,
+                    account: account,
+                    verb: :get,
                     endpoint: @list_targets)
   end
 
@@ -34,9 +36,9 @@ defmodule Zendesk.TargetsApi do
 
   """
   def show_target(account, id) do
-    perform_request(&Zendesk.Ticket.incremental_from_json_array/1, 
-                    account: account, 
-                    verb: :get, 
+    perform_request(&Zendesk.Ticket.incremental_from_json_array/1,
+                    account: account,
+                    verb: :get,
                     endpoint: ExPrintf.sprintf(@show_targets, [id]))
   end
 
@@ -50,12 +52,12 @@ defmodule Zendesk.TargetsApi do
   """
   def create_target(account, target) do
     json = Zendesk.Ticket.to_json(%{target: target})
-    perform_request(&Zendesk.Ticket.incremental_from_json_array/1, 
-                    account: account, 
-                    verb: :post, 
-                    endpoint: @create_target, 
-                    body: json, 
-                    headers: headers)
+    perform_request(&Zendesk.Ticket.incremental_from_json_array/1,
+                    account: account,
+                    verb: :post,
+                    endpoint: @create_target,
+                    body: json,
+                    headers: @headers)
   end
 
   @doc """
@@ -71,12 +73,12 @@ defmodule Zendesk.TargetsApi do
 
   def update_target(account, target, target_id) do
     json = Zendesk.Ticket.to_json(%{target: target})
-    perform_request(&Zendesk.Ticket.incremental_from_json_array/1, 
-                    account: account, 
-                    verb: :put, 
-                    endpoint: ExPrintf.sprintf(@update_target, [target_id]), 
-                    body: json, 
-                    headers: headers)
+    perform_request(&Zendesk.Ticket.incremental_from_json_array/1,
+                    account: account,
+                    verb: :put,
+                    endpoint: ExPrintf.sprintf(@update_target, [target_id]),
+                    body: json,
+                    headers: @headers)
   end
 
   @doc """
@@ -89,16 +91,13 @@ defmodule Zendesk.TargetsApi do
   """
 
   def delete_target(account, target_id) do
-    perform_request(&parse_delete/1, 
-                    account: account, 
-                    verb: :delete, 
-                    endpoint: ExPrintf.sprintf(@delete_target, [target_id]), 
-                    headers: headers)
+    perform_request(&parse_delete/1,
+                    account: account,
+                    verb: :delete,
+                    endpoint: ExPrintf.sprintf(@delete_target, [target_id]),
+                    headers: @headers)
   end
 
-  defp headers do
-    ["Content-Type": "application/json"]
-  end
   defp parse_delete(response) do
     response
   end

--- a/lib/api/ticket_api.ex
+++ b/lib/api/ticket_api.ex
@@ -24,6 +24,8 @@ defmodule Zendesk.TicketApi do
   @autocomplete_problems "/problems/autocomplete.json"
   @incremental_tickets "/incremental/tickets.json?start_time=%s"
 
+  @headers ["Content-Type": "application/json"]
+
   @doc """
   Create a ticket
 
@@ -31,7 +33,7 @@ defmodule Zendesk.TicketApi do
   """
   def create_ticket(account, ticket: ticket) do
     json = Ticket.to_json(%{ticket: ticket})
-    perform_request(&parse_single_ticket/1, account: account, verb: :post, endpoint: @create_endpoint, body: json, headers: headers)
+    perform_request(&parse_single_ticket/1, account: account, verb: :post, endpoint: @create_endpoint, body: json, headers: @headers)
   end
 
   @doc """
@@ -48,7 +50,7 @@ defmodule Zendesk.TicketApi do
     perform_request(&parse_single_ticket/1, account: account,
     verb: :put,
     endpoint: ExPrintf.sprintf(@ticket_with_id, [ticket_id]),
-    body: json, headers: headers)
+    body: json, headers: @headers)
   end
 
   @doc """
@@ -239,7 +241,7 @@ defmodule Zendesk.TicketApi do
     verb: :post,
     endpoint: @autocomplete_problems,
     body: autocomplete_body(text: text),
-    headers: headers)
+    headers: @headers)
   end
 
   @doc """
@@ -262,7 +264,7 @@ defmodule Zendesk.TicketApi do
     account: account, verb: :post,
     endpoint: ExPrintf.sprintf(@merge_tickets, [target_id]),
     body: merge_tickets_body(ids, target_comment, source_comment),
-    headers: headers)
+    headers: @headers)
   end
 
   # Private
@@ -278,10 +280,6 @@ defmodule Zendesk.TicketApi do
 
   defp ticket_url(id) do
     ExPrintf.sprintf(@ticket_with_id, [id])
-  end
-
-  defp headers do
-    ["Content-Type": "application/json"]
   end
 
   defp parse_delete_ticket(response) do

--- a/lib/api/ticket_fields_api.ex
+++ b/lib/api/ticket_fields_api.ex
@@ -4,13 +4,15 @@ defmodule Zendesk.TicketFieldsApi do
   Module that contains fucntions to deal with Zendesk ticket fields
   """
 
+  use Zendesk.CommonApi
+  alias Zendesk.TicketField
+
   @all_fields "/ticket_fields.json"
   @get_field "/ticket_fields/%s.json"
   @update_field "/ticket_fields/%s.json"
   @create_field "/ticket_fields.json"
 
-  use Zendesk.CommonApi
-  alias Zendesk.TicketField
+  @headers ["Content-Type": "application/json"]
 
 
   @doc """
@@ -39,7 +41,7 @@ defmodule Zendesk.TicketFieldsApi do
     json = TicketField.to_json(%{ticket_field: ticket_field})
 
     perform_request(&parse_ticket_field/1, account: account, verb: :post,
-    body: json, endpoint: @create_field, headers: headers)
+    body: json, endpoint: @create_field, headers: @headers)
   end
 
   @doc """
@@ -55,7 +57,7 @@ defmodule Zendesk.TicketFieldsApi do
     perform_request(&parse_ticket_field/1, account: account, verb: :put,
     body: json,
     endpoint: ExPrintf.sprintf(@update_field, [field_id]),
-    headers: headers)
+    headers: @headers)
   end
 
   @doc """
@@ -69,10 +71,6 @@ defmodule Zendesk.TicketFieldsApi do
   end
 
   # Private
-
-  defp headers do
-    ["Content-Type": "application/json"]
-  end
 
   defp parse_ticket_delete(response) do
     response

--- a/lib/api/triggers_api.ex
+++ b/lib/api/triggers_api.ex
@@ -1,15 +1,17 @@
-
 defmodule Zendesk.TriggersApi do
   @moduledoc """
   Module that contains fucntions to deal with Zendesk searches
   """
+
+  use Zendesk.CommonApi
 
   @list_triggers "/triggers.json"
   @get_triggers "/triggers/%s.json"
   @create_trigger "/triggers.json"
   @update_trigger "/triggers/%s.json"
   @delete_trigger "/triggers/%s.json"
-  use Zendesk.CommonApi
+
+  @headers ["Content-Type": "application/json"]
 
 
   @doc """
@@ -19,9 +21,9 @@ defmodule Zendesk.TriggersApi do
 
   """
   def list_triggers(account) do
-    perform_request(&Zendesk.Ticket.incremental_from_json_array/1, 
-                    account: account, 
-                    verb: :get, 
+    perform_request(&Zendesk.Ticket.incremental_from_json_array/1,
+                    account: account,
+                    verb: :get,
                     endpoint: @list_triggers)
   end
 
@@ -34,9 +36,9 @@ defmodule Zendesk.TriggersApi do
 
   """
   def get_triggers(account, id) do
-    perform_request(&Zendesk.Ticket.incremental_from_json_array/1, 
-                    account: account, 
-                    verb: :get, 
+    perform_request(&Zendesk.Ticket.incremental_from_json_array/1,
+                    account: account,
+                    verb: :get,
                     endpoint: ExPrintf.sprintf(@get_triggers, [id]))
   end
 
@@ -50,12 +52,12 @@ defmodule Zendesk.TriggersApi do
   """
   def create_trigger(account, trigger) do
     json = Zendesk.Ticket.to_json(%{trigger: trigger})
-    perform_request(&Zendesk.Ticket.incremental_from_json_array/1, 
-                    account: account, 
-                    verb: :post, 
-                    endpoint: @create_trigger, 
-                    body: json, 
-                    headers: headers)
+    perform_request(&Zendesk.Ticket.incremental_from_json_array/1,
+                    account: account,
+                    verb: :post,
+                    endpoint: @create_trigger,
+                    body: json,
+                    headers: @headers)
   end
 
   @doc """
@@ -71,12 +73,12 @@ defmodule Zendesk.TriggersApi do
 
   def update_trigger(account, trigger, trigger_id) do
     json = Zendesk.Ticket.to_json(%{trigger: trigger})
-    perform_request(&Zendesk.Ticket.incremental_from_json_array/1, 
-                    account: account, 
-                    verb: :put, 
-                    endpoint: ExPrintf.sprintf(@update_trigger, [trigger_id]), 
-                    body: json, 
-                    headers: headers)
+    perform_request(&Zendesk.Ticket.incremental_from_json_array/1,
+                    account: account,
+                    verb: :put,
+                    endpoint: ExPrintf.sprintf(@update_trigger, [trigger_id]),
+                    body: json,
+                    headers: @headers)
   end
 
   @doc """
@@ -89,20 +91,15 @@ defmodule Zendesk.TriggersApi do
   """
 
   def delete_trigger(account, trigger_id) do
-    perform_request(&parse_delete/1, 
-                    account: account, 
-                    verb: :delete, 
-                    endpoint: ExPrintf.sprintf(@delete_trigger, [trigger_id]), 
-                    headers: headers)
-  end
-
-  defp headers do
-    ["Content-Type": "application/json"]
+    perform_request(&parse_delete/1,
+                    account: account,
+                    verb: :delete,
+                    endpoint: ExPrintf.sprintf(@delete_trigger, [trigger_id]),
+                    headers: @headers)
   end
 
   defp parse_delete(response) do
     response
   end
-
 
 end

--- a/lib/api/user_fields_api.ex
+++ b/lib/api/user_fields_api.ex
@@ -18,7 +18,7 @@ defmodule Zendesk.UserFieldsApi do
   # Private
 
   defp parse_user_fields(response) do
-    Poison.Parser.parse(response, keys: :atoms) |> elem(1) |> Dict.get(:user_fields)
+    Poison.Parser.parse(response, keys: :atoms) |> elem(1) |> Map.get(:user_fields)
   end
 
 end

--- a/lib/api/view_api.ex
+++ b/lib/api/view_api.ex
@@ -17,6 +17,8 @@ defmodule Zendesk.ViewApi do
   @update_view "/views/%s.json"
   @count_view "/views/%s/count.json"
 
+  @headers ["Content-Type": "application/json"]
+
   use Zendesk.CommonApi
   alias Zendesk.View
 
@@ -60,7 +62,7 @@ defmodule Zendesk.ViewApi do
   def create_view(account, view) do
     perform_request(&parse_get_view/1, account: account, verb: :post,
     endpoint: @create_view,
-    headers: headers,
+    headers: @headers,
     body: View.to_json(view))
   end
 
@@ -72,7 +74,7 @@ defmodule Zendesk.ViewApi do
   def preview_view(account, view) do
     perform_request(&parse_get_tickets/1, account: account, verb: :post,
     endpoint: @preview_view,
-    headers: headers,
+    headers: @headers,
     body: View.to_json(view))
   end
 
@@ -84,7 +86,7 @@ defmodule Zendesk.ViewApi do
   def count_view_preview(account, view) do
     perform_request(&parse_view_count/1, account: account, verb: :post,
     endpoint: @preview_count_view,
-    headers: headers,
+    headers: @headers,
     body: View.to_json(view))
   end
 
@@ -98,7 +100,7 @@ defmodule Zendesk.ViewApi do
   def update_view(account, view_id: view_id, view: view) do
     perform_request(&parse_get_view/1, account: account, verb: :put,
     endpoint: ExPrintf.sprintf(@update_view, [view_id]),
-    headers: headers,
+    headers: @headers,
     body: View.to_json(view))
   end
 
@@ -155,16 +157,12 @@ defmodule Zendesk.ViewApi do
 
   # Private
 
-  defp headers do
-    ["Content-Type": "application/json"]
-  end
-
   defp parse_views_count(response) do
-    Poison.Parser.parse(response, keys: :atoms) |> elem(1) |> Dict.get(:view_counts)
+    Poison.Parser.parse(response, keys: :atoms) |> elem(1) |> Map.get(:view_counts)
   end
 
   defp parse_view_count(response) do
-    Poison.Parser.parse(response, keys: :atoms) |> elem(1) |> Dict.get(:view_count)
+    Poison.Parser.parse(response, keys: :atoms) |> elem(1) |> Map.get(:view_count)
   end
 
   defp parse_delete_view(response) do

--- a/lib/models/account.ex
+++ b/lib/models/account.ex
@@ -13,7 +13,7 @@ defmodule Zendesk.Account do
 
   `endpoint`: the resource endpoint
   """
-  def full_url(account, <<"https://">> <> rest = endpoint), do: URI.merge(domain(account), endpoint) |> to_string()
+  def full_url(account, <<"https://">> <> _rest = endpoint), do: URI.merge(domain(account), endpoint) |> to_string()
   def full_url(account, endpoint), do: domain(account) <> endpoint
 
   @doc """

--- a/lib/models/comment.ex
+++ b/lib/models/comment.ex
@@ -7,10 +7,10 @@ defmodule Zendesk.Comment do
   	%{}
   end
   def from_json(json) do
-    Poison.Parser.parse(json, keys: :atoms) |> elem(1) |> Dict.get(:comment)
+    Poison.Parser.parse(json, keys: :atoms) |> elem(1) |> Map.get(:comment)
   end
 
   def from_json_array(json) do
-    Poison.Parser.parse(json, keys: :atoms) |> elem(1) |> Dict.get(:comments)
+    Poison.Parser.parse(json, keys: :atoms) |> elem(1) |> Map.get(:comments)
   end
 end

--- a/lib/models/group.ex
+++ b/lib/models/group.ex
@@ -10,11 +10,11 @@ defmodule Zendesk.Group do
   `json`: the json to parse
   """
   def from_json_array(json) do
-    Poison.Parser.parse(json, keys: :atoms) |> elem(1) |> Dict.get(:groups)
+    Poison.Parser.parse(json, keys: :atoms) |> elem(1) |> Map.get(:groups)
   end
 
   def from_json(json) do
-    Poison.Parser.parse(json, keys: :atoms) |> elem(1) |> Dict.get(:group)
+    Poison.Parser.parse(json, keys: :atoms) |> elem(1) |> Map.get(:group)
   end
 
 end

--- a/lib/models/job_status.ex
+++ b/lib/models/job_status.ex
@@ -10,7 +10,7 @@ defmodule Zendesk.JobStatus do
   `json`: the json to parse
   """
   def from_json(json) do
-    Poison.Parser.parse(json, keys: :atoms) |> elem(1) |> Dict.get(:job_status)
+    Poison.Parser.parse(json, keys: :atoms) |> elem(1) |> Map.get(:job_status)
   end
 
 end

--- a/lib/models/organization.ex
+++ b/lib/models/organization.ex
@@ -10,7 +10,7 @@ defmodule Zendesk.Organization do
   `json`: the json to parse
   """
   def from_json(json) do
-    Poison.Parser.parse(json, keys: :atoms) |> elem(1) |> Dict.get(:organizations)
+    Poison.Parser.parse(json, keys: :atoms) |> elem(1) |> Map.get(:organizations)
   end
   
 end

--- a/lib/models/request.ex
+++ b/lib/models/request.ex
@@ -150,11 +150,11 @@ defmodule Zendesk.Request do
   end
 
   def from_json_array(json) do
-    Poison.Parser.parse(json, keys: :atoms) |> elem(1) |> Dict.get(:requests)
+    Poison.Parser.parse(json, keys: :atoms) |> elem(1) |> Map.get(:requests)
   end
 
   def from_json(json) do
-    Poison.Parser.parse(json, keys: :atoms) |> elem(1) |> Dict.get(:request)
+    Poison.Parser.parse(json, keys: :atoms) |> elem(1) |> Map.get(:request)
   end
 
 end

--- a/lib/models/ticket.ex
+++ b/lib/models/ticket.ex
@@ -239,7 +239,7 @@ defmodule Zendesk.Ticket do
   end
 
   def from_json(json) do
-    Poison.Parser.parse(json, keys: :atoms) |> elem(1) |> Dict.get(:ticket)
+    Poison.Parser.parse(json, keys: :atoms) |> elem(1) |> Map.get(:ticket)
   end
 
   def from_json_array(json) do
@@ -247,7 +247,7 @@ defmodule Zendesk.Ticket do
   end
 
   def from_json_array(json, key) do
-    Poison.Parser.parse(json, keys: :atoms) |> elem(1) |> Dict.get(key)
+    Poison.Parser.parse(json, keys: :atoms) |> elem(1) |> Map.get(key)
   end
 
   def incremental_from_json_array(json) do

--- a/lib/models/ticket_fields.ex
+++ b/lib/models/ticket_fields.ex
@@ -54,11 +54,11 @@ defmodule Zendesk.TicketField do
   end
 
   def from_json(json) do
-    Poison.Parser.parse(json, keys: :atoms) |> elem(1) |> Dict.get(:ticket_field)
+    Poison.Parser.parse(json, keys: :atoms) |> elem(1) |> Map.get(:ticket_field)
   end
 
   def from_json_array(json) do
-    Poison.Parser.parse(json, keys: :atoms) |> elem(1) |> Dict.get(:ticket_fields)
+    Poison.Parser.parse(json, keys: :atoms) |> elem(1) |> Map.get(:ticket_fields)
   end
 
 end

--- a/lib/models/ticket_metrics.ex
+++ b/lib/models/ticket_metrics.ex
@@ -10,11 +10,11 @@ defmodule Zendesk.TicketMetrics do
   `json`: the json to parse
   """
   def from_json_array(json) do
-    Poison.Parser.parse(json, keys: :atoms) |> elem(1) |> Dict.get(:ticket_metrics)
+    Poison.Parser.parse(json, keys: :atoms) |> elem(1) |> Map.get(:ticket_metrics)
   end
 
   def from_json(json) do
-    Poison.Parser.parse(json, keys: :atoms) |> elem(1) |> Dict.get(:ticket_metric)
+    Poison.Parser.parse(json, keys: :atoms) |> elem(1) |> Map.get(:ticket_metric)
   end
 
 end

--- a/lib/models/ticket_related.ex
+++ b/lib/models/ticket_related.ex
@@ -10,7 +10,7 @@ defmodule Zendesk.TicketRelated do
   `json`: the json to parse
   """
   def from_json(json) do
-    Poison.Parser.parse(json, keys: :atoms) |> elem(1) |> Dict.get(:ticket_related)
+    Poison.Parser.parse(json, keys: :atoms) |> elem(1) |> Map.get(:ticket_related)
   end
 
 end

--- a/lib/models/user.ex
+++ b/lib/models/user.ex
@@ -9,11 +9,11 @@ defmodule Zendesk.User do
   `json`: the json to parse
   """
   def from_json_array(json) do
-    Poison.Parser.parse(json, keys: :atoms) |> elem(1) |> Dict.get(:users)
+    Poison.Parser.parse(json, keys: :atoms) |> elem(1) |> Map.get(:users)
   end
 
   def from_json(json) do
-    Poison.Parser.parse(json, keys: :atoms) |> elem(1) |> Dict.get(:user)
+    Poison.Parser.parse(json, keys: :atoms) |> elem(1) |> Map.get(:user)
   end
 
 end

--- a/lib/models/view.ex
+++ b/lib/models/view.ex
@@ -86,11 +86,11 @@ defmodule Zendesk.View do
   end
 
   def from_json(json) do
-    Poison.Parser.parse(json, keys: :atoms) |> elem(1) |> Dict.get(:view)
+    Poison.Parser.parse(json, keys: :atoms) |> elem(1) |> Map.get(:view)
   end
 
   def from_json_array(json) do
-    Poison.Parser.parse(json, keys: :atoms) |> elem(1) |> Dict.get(:views)
+    Poison.Parser.parse(json, keys: :atoms) |> elem(1) |> Map.get(:views)
   end
 
 end

--- a/mix.exs
+++ b/mix.exs
@@ -5,11 +5,12 @@ defmodule NewTest.Mixfile do
     [app: :zenixir,
      version: "0.0.1",
      elixir: "~> 1.2",
+     description: description(),
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
      test_coverage: [tool: ExCoveralls],
      preferred_cli_env: ["coveralls": :test, "coveralls.detail": :test, "coveralls.post": :test, "coveralls.html": :test],
-     deps: deps]
+     deps: deps()]
   end
 
   # Configuration for the OTP application

--- a/mix.lock
+++ b/mix.lock
@@ -5,7 +5,7 @@
   "exactor": {:hex, :exactor, "2.2.2", "90b27d72c05614801a60f8400afd4e4346dfc33ea9beffe3b98a794891d2ff96", [], []},
   "excoveralls": {:hex, :excoveralls, "0.5.7", "5d26e4a7cdf08294217594a1b0643636accc2ad30e984d62f1d166f70629ff50", [], [{:exjsx, "~> 3.0", [hex: :exjsx, optional: false]}, {:hackney, ">= 0.12.0", [hex: :hackney, optional: false]}]},
   "exjsx": {:hex, :exjsx, "3.2.1", "1bc5bf1e4fd249104178f0885030bcd75a4526f4d2a1e976f4b428d347614f0f", [], [{:jsx, "~> 2.8.0", [hex: :jsx, optional: false]}]},
-  "exprintf": {:git, "https://github.com/parroty/exprintf.git", "4c498c8b580d15b91655acae1e41d0e432ff686f", []},
+  "exprintf": {:git, "https://github.com/parroty/exprintf.git", "608ee65eca200638b2d3548beb134b7dad0e75f6", []},
   "exvcr": {:hex, :exvcr, "0.8.4", "23ce3a7ff428ed98127292da1b6d04418064391d1045c00cd8ee2da37c5b839b", [:mix], [{:exactor, "~> 2.2", [hex: :exactor, optional: false]}, {:exjsx, "~> 3.2", [hex: :exjsx, optional: false]}, {:httpoison, "~> 0.8", [hex: :httpoison, optional: true]}, {:httpotion, "~> 3.0", [hex: :httpotion, optional: true]}, {:ibrowse, "~> 4.2.2", [hex: :ibrowse, optional: true]}, {:meck, "~> 0.8.3", [hex: :meck, optional: false]}]},
   "hackney": {:hex, :hackney, "1.6.3", "d489d7ca2d4323e307bedc4bfe684323a7bf773ecfd77938f3ee8074e488e140", [:mix, :rebar3], [{:certifi, "0.7.0", [hex: :certifi, optional: false]}, {:idna, "1.2.0", [hex: :idna, optional: false]}, {:metrics, "1.0.1", [hex: :metrics, optional: false]}, {:mimerl, "1.0.2", [hex: :mimerl, optional: false]}, {:ssl_verify_fun, "1.1.1", [hex: :ssl_verify_fun, optional: false]}]},
   "httpoison": {:hex, :httpoison, "0.10.0", "4727b3a5e57e9a4ff168a3c2883e20f1208103a41bccc4754f15a9366f49b676", [:mix], [{:hackney, "~> 1.6.3", [hex: :hackney, optional: false]}]},

--- a/test/automations_test.exs
+++ b/test/automations_test.exs
@@ -19,8 +19,8 @@ defmodule AutomationsTest do
     email: "test@test.com", password: "test")
     |> show_ticket(ticket_id: "587")
 
-    assert res |> Dict.get(:id) == 587
-    assert res |> Dict.get(:subject) == "The subject"
+    assert res |> Map.get(:id) == 587
+    assert res |> Map.get(:subject) == "The subject"
     end
   end
 
@@ -32,7 +32,7 @@ defmodule AutomationsTest do
       email: "test@test.com", password: "test")
       |> show_tickets(ids: ["1", "587"])
 
-      assert res |> hd |> Dict.get(:id) == 1
+      assert res |> hd |> Map.get(:id) == 1
       assert length(res) == 2
     end
   end

--- a/test/brand_test.exs
+++ b/test/brand_test.exs
@@ -12,7 +12,7 @@ defmodule BrandTest do
       |> all_brands
 
       assert length(res) == 2
-      assert res |> hd |> Dict.get(:name) == "BrandOne"
+      assert res |> hd |> Map.get(:name) == "BrandOne"
     end
   end
 

--- a/test/client_test.exs
+++ b/test/client_test.exs
@@ -12,7 +12,7 @@ defmodule ClientTest do
       |> Client.request(resource: "organization_memberships.json")
 
       assert length(res.organization_memberships) == 1
-      assert res.organization_memberships |> hd |> Dict.get(:user_id) == 236084977
+      assert res.organization_memberships |> hd |> Map.get(:user_id) == 236084977
     end
   end
 

--- a/test/group_membership_test.exs
+++ b/test/group_membership_test.exs
@@ -12,7 +12,7 @@ defmodule GroupMEmbershipTest do
       |> all_group_membership
 
       assert length(res) == 30
-      assert res |> hd |> Dict.get(:group_id) == 20305157
+      assert res |> hd |> Map.get(:group_id) == 20305157
     end
   end
 
@@ -23,7 +23,7 @@ defmodule GroupMEmbershipTest do
       |> all_group_membership(user_id: "237064573")
 
       assert length(res) == 3
-      assert res |> hd |> Dict.get(:group_id) == 20305157
+      assert res |> hd |> Map.get(:group_id) == 20305157
     end
   end
 
@@ -34,7 +34,7 @@ defmodule GroupMEmbershipTest do
       |> all_group_membership(group_id: "21554407")
 
       assert length(res) == 5
-      assert res |> hd |> Dict.get(:group_id) == 21554407
+      assert res |> hd |> Map.get(:group_id) == 21554407
     end
   end
 

--- a/test/organization_test.exs
+++ b/test/organization_test.exs
@@ -12,7 +12,7 @@ defmodule OrganizationTest do
       |> all_organizations
 
       assert length(res) == 2
-      assert res |> hd |> Dict.get(:name) == "[TEST] Mobile - Enterprise - Testing - Z3N"
+      assert res |> hd |> Map.get(:name) == "[TEST] Mobile - Enterprise - Testing - Z3N"
     end
   end
 
@@ -23,7 +23,7 @@ defmodule OrganizationTest do
       |> all_organizations(user_id: "236084977")
 
       assert length(res) == 1
-      assert res |> hd |> Dict.get(:name) == "Mobile - Enterprise - Testing - Z3N"
+      assert res |> hd |> Map.get(:name) == "Mobile - Enterprise - Testing - Z3N"
     end
   end
 
@@ -34,7 +34,7 @@ defmodule OrganizationTest do
       |> autocomplete_organizations(name: "test")
 
       assert length(res) == 1
-      assert res |> hd |> Dict.get(:name) == "Mobile - Enterprise - Testing - Z3N"
+      assert res |> hd |> Map.get(:name) == "Mobile - Enterprise - Testing - Z3N"
     end
   end
 

--- a/test/requests_test.exs
+++ b/test/requests_test.exs
@@ -12,7 +12,7 @@ defmodule RequestTest do
       |> all_requests
 
       assert length(res) == 56
-      assert res |> hd |> Dict.get(:subject) == "This is a sample ticket requested and submitted by you"
+      assert res |> hd |> Map.get(:subject) == "This is a sample ticket requested and submitted by you"
     end
   end
 
@@ -23,7 +23,7 @@ defmodule RequestTest do
       |> all_requests(statuses: ["open", "closed"])
 
       assert length(res) == 56
-      assert res |> hd |> Dict.get(:subject) == "This is a sample ticket requested and submitted by you"
+      assert res |> hd |> Map.get(:subject) == "This is a sample ticket requested and submitted by you"
     end
   end
 
@@ -34,7 +34,7 @@ defmodule RequestTest do
       |> all_requests(user_id: "4096938127")
 
       assert length(res) == 56
-      assert res |> hd |> Dict.get(:subject) == "This is a sample ticket requested and submitted by you"
+      assert res |> hd |> Map.get(:subject) == "This is a sample ticket requested and submitted by you"
     end
   end
 
@@ -45,7 +45,7 @@ defmodule RequestTest do
       |> all_requests(organization_id: "22016037")
 
       assert length(res) == 56
-      assert res |> hd |> Dict.get(:subject) == "This is a sample ticket requested and submitted by you"
+      assert res |> hd |> Map.get(:subject) == "This is a sample ticket requested and submitted by you"
     end
   end
 
@@ -56,7 +56,7 @@ defmodule RequestTest do
       |> search_requests(query: "sample ticket")
 
       assert length(res) == 56
-      assert res |> hd |> Dict.get(:subject) == "This is a sample ticket requested and submitted by you"
+      assert res |> hd |> Map.get(:subject) == "This is a sample ticket requested and submitted by you"
     end
   end
 

--- a/test/scratch_test.exs
+++ b/test/scratch_test.exs
@@ -11,7 +11,7 @@
 #       email: "test@test.com", password: "test")
 #       |> tickets_with_ids(ids: ["1", "587"])
 #
-#       assert res |> hd |> Dict.get(:id) == 1
+#       assert res |> hd |> Map.get(:id) == 1
 #       assert length(res) == 2
 #     end
 #   end
@@ -25,7 +25,7 @@
 #   #   |> ticket_with_id(id: "587")
 #   #
 #   #   res |> IO.inspect
-#   #   # assert res |> hd |> Dict.get(:raw_subject) == "This is a sample ticket requested and submitted by you"
+#   #   # assert res |> hd |> Map.get(:raw_subject) == "This is a sample ticket requested and submitted by you"
 #   #   # assert length(res) == 50
 #   #   # end
 #   #

--- a/test/search_test.exs
+++ b/test/search_test.exs
@@ -12,7 +12,7 @@ defmodule SeatchTest do
       |> search(type: :user, query: "Tags")
 
       assert length(res.results) == 1
-      assert res.results |> hd |> Dict.get(:name) == "No Tags Agent"
+      assert res.results |> hd |> Map.get(:name) == "No Tags Agent"
     end
   end
 
@@ -23,7 +23,7 @@ defmodule SeatchTest do
       |> search(query: "type:ticket Ticket with Attachments")
 
       assert length(res.results) == 1
-      assert res.results |> hd |> Dict.get(:subject) == "Ticket with Attachments (DO NOT SOLVE OR DELETE)"
+      assert res.results |> hd |> Map.get(:subject) == "Ticket with Attachments (DO NOT SOLVE OR DELETE)"
     end
   end
 

--- a/test/tags_test.exs
+++ b/test/tags_test.exs
@@ -12,7 +12,7 @@ defmodule TagTest do
       |> all_tags
 
       assert length(res) == 52
-      assert res |> hd |> Dict.get(:name) == "tag_one"
+      assert res |> hd |> Map.get(:name) == "tag_one"
     end
   end
 

--- a/test/ticket_fields_test.exs
+++ b/test/ticket_fields_test.exs
@@ -42,7 +42,7 @@ defmodule TicketFieldsTest do
     |> TicketField.add_custom_field_option(name: "option2", value: "value2")
 
     assert field.custom_field_options |> length == 2
-    assert field.custom_field_options |> hd |> Dict.get(:name) == "option1"
+    assert field.custom_field_options |> hd |> Map.get(:name) == "option1"
   end
 
   test "it can create a ticket field" do
@@ -58,7 +58,7 @@ defmodule TicketFieldsTest do
       assert res |> Map.get(:title) == "Age"
 
       assert res.custom_field_options |> length == 2
-      assert res.custom_field_options |> hd |> Dict.get(:name) == "Option 1"
+      assert res.custom_field_options |> hd |> Map.get(:name) == "Option 1"
     end
   end
 

--- a/test/ticket_metrics_test.exs
+++ b/test/ticket_metrics_test.exs
@@ -12,7 +12,7 @@ defmodule TicketMetricsTest do
       |> all_metrics
 
       assert length(res) == 100
-      assert res |> hd |> Dict.get(:id) == 2738394508
+      assert res |> hd |> Map.get(:id) == 2738394508
     end
   end
 

--- a/test/ticket_test.exs
+++ b/test/ticket_test.exs
@@ -128,8 +128,8 @@ defmodule TicketTest do
     ticket = ticket |> Ticket.add_collaborator(name: "Test1", email: "t1@t.com")
     assert ticket.collaborators |> length == 2
 
-    assert ticket.collaborators |> Enum.at(0) |> Dict.get(:name) == "Test"
-    assert ticket.collaborators |> Enum.at(1) |> Dict.get(:name) == "Test1"
+    assert ticket.collaborators |> Enum.at(0) |> Map.get(:name) == "Test"
+    assert ticket.collaborators |> Enum.at(1) |> Map.get(:name) == "Test1"
 
     ticket = ticket |> Ticket.add_collaborator(id: "12345")
     assert ticket.collaborators |> length == 3
@@ -149,8 +149,8 @@ defmodule TicketTest do
     ticket = ticket |> Ticket.add_custom_fields("2", "Value2")
     assert ticket.custom_fields |> length == 2
 
-    assert ticket.custom_fields |> Enum.at(0) |> Dict.get(:value) == "Value1"
-    assert ticket.custom_fields |> Enum.at(1) |> Dict.get(:value) == "Value2"
+    assert ticket.custom_fields |> Enum.at(0) |> Map.get(:value) == "Value1"
+    assert ticket.custom_fields |> Enum.at(1) |> Map.get(:value) == "Value2"
     # assert ticket.status == "open"
   end
 
@@ -295,7 +295,7 @@ defmodule TicketTest do
         |> all_tickets
 
         assert length(res.tickets) == 100
-        assert res.tickets |> hd |> Dict.get(:id) == 1
+        assert res.tickets |> hd |> Map.get(:id) == 1
       end
     end
 
@@ -306,7 +306,7 @@ defmodule TicketTest do
         email: "email@me.com", token: "jt82RfMETyIBzCBQwNuLeCh4YxdAps8rJeN99SW2")
         |> recent_tickets
 
-        assert res |> hd |> Dict.get(:raw_subject) == "The subject2"
+        assert res |> hd |> Map.get(:raw_subject) == "The subject2"
         assert length(res) == 5
       end
     end
@@ -318,7 +318,7 @@ defmodule TicketTest do
           email: "email@me.com", token: "jt82RfMETyIBzCBQwNuLeCh4YxdAps8rJeN99SW2")
         |> show_ticket(requester_id: "4047329778")
 
-        assert res |> hd |> Dict.get(:raw_subject) == "The subject"
+        assert res |> hd |> Map.get(:raw_subject) == "The subject"
         assert length(res) == 18
       end
     end
@@ -330,7 +330,7 @@ defmodule TicketTest do
           email: "email@me.com", token: "jt82RfMETyIBzCBQwNuLeCh4YxdAps8rJeN99SW2")
         |> show_ticket(assignee_id: "236084977")
 
-        assert res |> hd |> Dict.get(:raw_subject) == "Yiuiib"
+        assert res |> hd |> Map.get(:raw_subject) == "Yiuiib"
         assert length(res) == 4
       end
     end
@@ -342,7 +342,7 @@ defmodule TicketTest do
           email: "email@me.com", token: "jt82RfMETyIBzCBQwNuLeCh4YxdAps8rJeN99SW2")
         |> show_ticket(cc_id: "236084977")
 
-        assert res |> hd |> Dict.get(:raw_subject) == "Yiuiib"
+        assert res |> hd |> Map.get(:raw_subject) == "Yiuiib"
         assert length(res) == 1
       end
     end
@@ -354,7 +354,7 @@ defmodule TicketTest do
           email: "email@me.com", token: "jt82RfMETyIBzCBQwNuLeCh4YxdAps8rJeN99SW2")
         |> show_ticket(organization_id: "22016037")
 
-        assert res |> hd |> Dict.get(:raw_subject) == "This is a sample ticket requested and submitted by you"
+        assert res |> hd |> Map.get(:raw_subject) == "This is a sample ticket requested and submitted by you"
         assert length(res) == 50
       end
     end
@@ -367,8 +367,8 @@ defmodule TicketTest do
     email: "test@test.com", password: "test")
     |> show_ticket(ticket_id: "587")
 
-    assert res |> Dict.get(:id) == 587
-    assert res |> Dict.get(:subject) == "The subject"
+    assert res |> Map.get(:id) == 587
+    assert res |> Map.get(:subject) == "The subject"
     end
   end
 
@@ -380,7 +380,7 @@ defmodule TicketTest do
       email: "test@test.com", password: "test")
       |> show_tickets(ids: ["1", "587"])
 
-      assert res |> hd |> Dict.get(:id) == 1
+      assert res |> hd |> Map.get(:id) == 1
       assert length(res) == 2
     end
   end

--- a/test/user_fields_test.exs
+++ b/test/user_fields_test.exs
@@ -12,7 +12,7 @@ defmodule UserFieldsTest do
       |> all_user_fields
 
       assert length(res) == 1
-      assert res |> hd |> Dict.get(:title) == "test2"
+      assert res |> hd |> Map.get(:title) == "test2"
     end
   end
 

--- a/test/view_test.exs
+++ b/test/view_test.exs
@@ -12,7 +12,7 @@ defmodule ViewTest do
       |> all_views
 
       assert length(res) == 11
-      assert res |> hd |> Dict.get(:id) == 29292517
+      assert res |> hd |> Map.get(:id) == 29292517
     end
   end
 
@@ -23,7 +23,7 @@ defmodule ViewTest do
       |> active_views
 
       assert length(res) == 9
-      assert res |> hd |> Dict.get(:id) == 29292517
+      assert res |> hd |> Map.get(:id) == 29292517
     end
   end
 
@@ -34,7 +34,7 @@ defmodule ViewTest do
       |> compact_views
 
       assert length(res) == 9
-      assert res |> hd |> Dict.get(:id) == 29292517
+      assert res |> hd |> Map.get(:id) == 29292517
     end
   end
 


### PR DESCRIPTION
- update exprintf dep to remove its warnings
- replace deprecated Dict.get with Map.get or Keyword.get as appropriate
- replace defp headers with @headers module attribute
- add parens to 0 param function calls in mix.exs
- add description to project config in mix.exs
- update readme with new github user